### PR TITLE
Add retries for V2 api Get & Delete requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/tabular-io/terraform-provider-tabular
 go 1.20
 
 require (
+	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-framework v1.1.1
 	github.com/hashicorp/terraform-plugin-go v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgI
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
+github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
+github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
 github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEMs=
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
@@ -165,8 +167,6 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/tabular-io/tabular-sdk-go v1.0.4 h1:vqOxnLC1ahI8tIaQVnAUjuu/8ZqnqwsSp94KTldychQ=
-github.com/tabular-io/tabular-sdk-go v1.0.4/go.mod h1:WCiZVZvrXBi73BKeHTjTeJ4SNsFDo/6MRNf1FBubWc0=
 github.com/tabular-io/tabular-sdk-go v1.0.5 h1:vLQowv1ZsPl4pxL5EUDujGch1V+2SFmwM58bnO2rSew=
 github.com/tabular-io/tabular-sdk-go v1.0.5/go.mod h1:WCiZVZvrXBi73BKeHTjTeJ4SNsFDo/6MRNf1FBubWc0=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/provider/aws_role_mapping.go
+++ b/internal/provider/aws_role_mapping.go
@@ -83,7 +83,8 @@ func (r *awsRoleMappingResource) Read(ctx context.Context, req resource.ReadRequ
 	}
 
 	credentialKey := state.Id.ValueString()
-	roleMappingAWS, _, err := r.client.V2.DefaultAPI.GetCredential(ctx, *r.client.OrganizationId, credentialKey).Execute()
+	retryFunc := util.RetryResourceResponse[*tabular.GetCredentialResponse]
+	roleMappingAWS, _, err := retryFunc(r.client.V2.DefaultAPI.GetCredential(ctx, *r.client.OrganizationId, credentialKey).Execute)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to read service account", "Unable to read service account "+err.Error())
 		return
@@ -149,7 +150,7 @@ func (r *awsRoleMappingResource) Delete(ctx context.Context, req resource.Delete
 	var state awsRoleMappingResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 
-	_, err := r.client.V2.DefaultAPI.DeleteServiceAccountCredential(ctx, *r.client.OrganizationId, state.Id.ValueString()).Execute()
+	_, err := util.RetryResponse(r.client.V2.DefaultAPI.DeleteServiceAccountCredential(ctx, *r.client.OrganizationId, state.Id.ValueString()).Execute)
 
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting roleMappingAWS", "Unable to delete roleMappingAWS "+err.Error())

--- a/internal/provider/role.go
+++ b/internal/provider/role.go
@@ -82,7 +82,8 @@ func (r *roleResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	}
 
 	roleName := state.Name.ValueString()
-	role, _, err := r.client.V2.DefaultAPI.GetRole(ctx, *r.client.OrganizationId, roleName).Execute()
+	retryFunc := util.RetryResourceResponse[*tabular.GetRoleResponse]
+	role, _, err := retryFunc(r.client.V2.DefaultAPI.GetRole(ctx, *r.client.OrganizationId, roleName).Execute)
 	if err != nil {
 		resp.Diagnostics.AddError("Error fetching role", "Could not fetch role "+roleName+": "+err.Error())
 		return
@@ -157,7 +158,7 @@ func (r *roleResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 
 	forceDestroy := data.ForceDestroy.ValueBool()
 	roleName := data.Name.ValueString()
-	_, err := r.client.V2.DefaultAPI.DeleteRole(ctx, *r.client.OrganizationId, roleName).Force(forceDestroy).Execute()
+	_, err := util.RetryResponse(r.client.V2.DefaultAPI.DeleteRole(ctx, *r.client.OrganizationId, roleName).Force(forceDestroy).Execute)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting role", "Something went wrong. Does the role still have any users/roles/permissions attached to it? Err: "+err.Error())
 		return

--- a/internal/provider/s3_storage_profile.go
+++ b/internal/provider/s3_storage_profile.go
@@ -75,7 +75,8 @@ func (r *storageProfileS3Resource) Schema(ctx context.Context, req resource.Sche
 func (r *storageProfileS3Resource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	bucketName := types.StringValue(req.ID)
 
-	getStorageProfileResp, _, err := util.RetryResourceResponse[*tabular.GetStorageProfileResponse](r.client.V2.DefaultAPI.GetStorageProfile(ctx, *r.client.OrganizationId, bucketName.ValueString()).Type_("name").Execute)
+	retryFunc := util.RetryResourceResponse[*tabular.GetStorageProfileResponse]
+	getStorageProfileResp, _, err := retryFunc(r.client.V2.DefaultAPI.GetStorageProfile(ctx, *r.client.OrganizationId, bucketName.ValueString()).Type_("name").Execute)
 
 	if err != nil {
 		resp.Diagnostics.AddError("Error getting storage profile", "Could not get storage profile "+err.Error())
@@ -102,7 +103,8 @@ func (r *storageProfileS3Resource) Read(ctx context.Context, req resource.ReadRe
 	}
 
 	storageProfileId := state.Id.ValueString()
-	storageProfile, _, err := util.RetryResourceResponse[*tabular.GetStorageProfileResponse](r.client.V2.DefaultAPI.GetStorageProfile(ctx, *r.client.OrganizationId, storageProfileId).Execute)
+	retryFunc := util.RetryResourceResponse[*tabular.GetStorageProfileResponse]
+	storageProfile, _, err := retryFunc(r.client.V2.DefaultAPI.GetStorageProfile(ctx, *r.client.OrganizationId, storageProfileId).Execute)
 	if err != nil {
 		resp.Diagnostics.AddError("Error getting storage profile", "Could not get storage profile "+err.Error())
 		return
@@ -146,7 +148,8 @@ func (r *storageProfileS3Resource) Create(ctx context.Context, req resource.Crea
 	s3Bucket := plan.Bucket.ValueString()
 	iamRoleArn := plan.RoleArn.ValueString()
 
-	storageProfileResponse, _, err := util.RetryResourceResponse[*tabular.CreateS3StorageProfileResponse](r.client.V2.DefaultAPI.CreateStorageProfile(ctx, *r.client.OrganizationId).
+	retryFunc := util.RetryResourceResponse[*tabular.CreateS3StorageProfileResponse]
+	storageProfileResponse, _, err := retryFunc(r.client.V2.DefaultAPI.CreateStorageProfile(ctx, *r.client.OrganizationId).
 		CreateS3StorageProfileRequest(tabular.CreateS3StorageProfileRequest{
 			Region:  &region,
 			Bucket:  &s3Bucket,

--- a/internal/provider/s3_storage_profile.go
+++ b/internal/provider/s3_storage_profile.go
@@ -148,13 +148,12 @@ func (r *storageProfileS3Resource) Create(ctx context.Context, req resource.Crea
 	s3Bucket := plan.Bucket.ValueString()
 	iamRoleArn := plan.RoleArn.ValueString()
 
-	retryFunc := util.RetryResourceResponse[*tabular.CreateS3StorageProfileResponse]
-	storageProfileResponse, _, err := retryFunc(r.client.V2.DefaultAPI.CreateStorageProfile(ctx, *r.client.OrganizationId).
+	storageProfileResponse, _, err := r.client.V2.DefaultAPI.CreateStorageProfile(ctx, *r.client.OrganizationId).
 		CreateS3StorageProfileRequest(tabular.CreateS3StorageProfileRequest{
 			Region:  &region,
 			Bucket:  &s3Bucket,
 			RoleArn: &iamRoleArn,
-		}).Execute)
+		}).Execute()
 
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating storage profile", "Unable to create storage profile "+err.Error())

--- a/internal/provider/service_account.go
+++ b/internal/provider/service_account.go
@@ -100,7 +100,8 @@ func (r *serviceAccountResource) Read(ctx context.Context, req resource.ReadRequ
 	}
 
 	credentialKey := state.Id.ValueString()
-	serviceAccount, _, err := r.client.V2.DefaultAPI.GetCredential(ctx, *r.client.OrganizationId, credentialKey).Execute()
+	retryFunc := util.RetryResourceResponse[*tabular.GetCredentialResponse]
+	serviceAccount, _, err := retryFunc(r.client.V2.DefaultAPI.GetCredential(ctx, *r.client.OrganizationId, credentialKey).Execute)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to read service account", "Unable to read service account "+err.Error())
 		return
@@ -169,7 +170,7 @@ func (r *serviceAccountResource) Delete(ctx context.Context, req resource.Delete
 	var state serviceAccountResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 
-	_, err := r.client.V2.DefaultAPI.DeleteServiceAccountCredential(ctx, *r.client.OrganizationId, state.CredentialKey.ValueString()).Execute()
+	_, err := util.RetryResponse(r.client.V2.DefaultAPI.DeleteServiceAccountCredential(ctx, *r.client.OrganizationId, state.CredentialKey.ValueString()).Execute)
 
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting serviceAccount", "Unable to delete serviceAccount "+err.Error())

--- a/internal/provider/util/retry.go
+++ b/internal/provider/util/retry.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"net/http"
+	"time"
 
 	backoff "github.com/cenkalti/backoff/v4"
 )
@@ -22,15 +23,29 @@ func (rro *resourceResponseOperation[T]) Execute() (resourceResponse[T], error) 
 	return resourceResponse[T]{resource, response}, error
 }
 
+func getExponentialBackOff() *backoff.ExponentialBackOff {
+	b := &backoff.ExponentialBackOff{
+		InitialInterval:     backoff.DefaultInitialInterval,
+		RandomizationFactor: backoff.DefaultRandomizationFactor,
+		Multiplier:          2,
+		MaxInterval:         backoff.DefaultMaxInterval,
+		MaxElapsedTime:      5 * time.Minute,
+		Stop:                backoff.Stop,
+		Clock:               backoff.SystemClock,
+	}
+	b.Reset()
+	return b
+}
+
 // For requests that return resource info, a response and a error
 // This function combines that into one struct so the retry library can be used and then flattens before returning
 func RetryResourceResponse[T any](operationWithResourceResponse operationWithResourceResponseData[T]) (T, *http.Response, error) {
 	rro := resourceResponseOperation[T]{operationWithResourceResponse}
-	resourceResponse, err := backoff.RetryWithData[resourceResponse[T]](rro.Execute, backoff.NewExponentialBackOff())
+	resourceResponse, err := backoff.RetryWithData[resourceResponse[T]](rro.Execute, getExponentialBackOff())
 	return resourceResponse.Resource, resourceResponse.Response, err
 }
 
 // For requests that just return a response and an error
 func RetryResponse(operationWithData backoff.OperationWithData[*http.Response]) (*http.Response, error) {
-	return backoff.RetryWithData[*http.Response](operationWithData, backoff.NewExponentialBackOff())
+	return backoff.RetryWithData[*http.Response](operationWithData, getExponentialBackOff())
 }

--- a/internal/provider/util/retry.go
+++ b/internal/provider/util/retry.go
@@ -30,7 +30,7 @@ func RetryResourceResponse[T any](operationWithResourceResponse operationWithRes
 	return resourceResponse.Resource, resourceResponse.Response, err
 }
 
-// For requests that just resturn a response and an error
+// For requests that just return a response and an error
 func RetryResponse(operationWithData backoff.OperationWithData[*http.Response]) (*http.Response, error) {
 	return backoff.RetryWithData[*http.Response](operationWithData, backoff.NewExponentialBackOff())
 }

--- a/internal/provider/util/retry.go
+++ b/internal/provider/util/retry.go
@@ -1,0 +1,36 @@
+package util
+
+import (
+	"net/http"
+
+	backoff "github.com/cenkalti/backoff/v4"
+)
+
+type resourceResponse[T any] struct {
+	Resource T
+	Response *http.Response
+}
+
+type operationWithResourceResponseData[T any] func() (T, *http.Response, error)
+
+type resourceResponseOperation[T any] struct {
+	operation operationWithResourceResponseData[T]
+}
+
+func (rro *resourceResponseOperation[T]) Execute() (resourceResponse[T], error) {
+	resource, response, error := rro.operation()
+	return resourceResponse[T]{resource, response}, error
+}
+
+// For requests that return resource info, a response and a error
+// This function combines that into one struct so the retry library can be used and then flattens before returning
+func RetryResourceResponse[T any](operationWithResourceResponse operationWithResourceResponseData[T]) (T, *http.Response, error) {
+	rro := resourceResponseOperation[T]{operationWithResourceResponse}
+	resourceResponse, err := backoff.RetryWithData[resourceResponse[T]](rro.Execute, backoff.NewExponentialBackOff())
+	return resourceResponse.Resource, resourceResponse.Response, err
+}
+
+// For requests that just resturn a response and an error
+func RetryResponse(operationWithData backoff.OperationWithData[*http.Response]) (*http.Response, error) {
+	return backoff.RetryWithData[*http.Response](operationWithData, backoff.NewExponentialBackOff())
+}

--- a/internal/provider/warehouse.go
+++ b/internal/provider/warehouse.go
@@ -83,8 +83,9 @@ func (r *warehouseResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
+	retryFunc := util.RetryResourceResponse[*tabular.GetWarehouseResponse]
 	warehouseId := state.Id.ValueString()
-	warehouse, _, err := util.RetryResourceResponse[*tabular.GetWarehouseResponse](
+	warehouse, _, err := retryFunc(
 		r.client.V2.DefaultAPI.GetWarehouse(ctx, *r.client.OrganizationId, warehouseId).Execute,
 	)
 	if err != nil {
@@ -116,8 +117,9 @@ func (r *warehouseResource) Create(ctx context.Context, req resource.CreateReque
 	warehouseName := plan.Name.ValueString()
 	storageProfileId := plan.StorageProfile.ValueString()
 
+	retryFunc := util.RetryResourceResponse[*tabular.CreateWarehouseResponse]
 	apiCreateWarehouseRequest := r.client.V2.DefaultAPI.CreateWarehouse(ctx, *r.client.OrganizationId)
-	warehouseResponse, _, err := util.RetryResourceResponse[*tabular.CreateWarehouseResponse](apiCreateWarehouseRequest.
+	warehouseResponse, _, err := retryFunc(apiCreateWarehouseRequest.
 		CreateWarehouseRequest(tabular.CreateWarehouseRequest{
 			Name:             &warehouseName,
 			StorageProfileId: &storageProfileId,

--- a/internal/provider/warehouse.go
+++ b/internal/provider/warehouse.go
@@ -117,13 +117,12 @@ func (r *warehouseResource) Create(ctx context.Context, req resource.CreateReque
 	warehouseName := plan.Name.ValueString()
 	storageProfileId := plan.StorageProfile.ValueString()
 
-	retryFunc := util.RetryResourceResponse[*tabular.CreateWarehouseResponse]
 	apiCreateWarehouseRequest := r.client.V2.DefaultAPI.CreateWarehouse(ctx, *r.client.OrganizationId)
-	warehouseResponse, _, err := retryFunc(apiCreateWarehouseRequest.
+	warehouseResponse, _, err := apiCreateWarehouseRequest.
 		CreateWarehouseRequest(tabular.CreateWarehouseRequest{
 			Name:             &warehouseName,
 			StorageProfileId: &storageProfileId,
-		}).Execute)
+		}).Execute()
 
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating storage profile", "Unable to create storage profile "+err.Error())


### PR DESCRIPTION
- Adding retry wrapper methods on the most used golang retry lib https://pkg.go.dev/github.com/cenkalti/backoff/v4@v4.2.1
- Using them for all v2 get and delete requests
- This is needed as some of the API calls are async and therefore related resources' deletes may need to be retried
- [Not covered in this PR] Retries for v1 requests since they do not use the SDK, will need to do some refactoring to get a generic retry method for them
- Current backoff config leads to following times (with some randomness the algo uses)

```
 Request #  RetryInterval (seconds)

  1          0.5
  2          1
  3          2
  4          4
  5          8
  6          16
  7          32
  8         64
  9         128
 10         [Will hit max time before executing]
```