### PR TITLE
Fix reference to warehouse name for tf dependency graph

### DIFF
--- a/internal/provider/warehouse_data_source_test.go
+++ b/internal/provider/warehouse_data_source_test.go
@@ -43,9 +43,9 @@ resource "tabular_warehouse" "test" {
 }
 
 data "tabular_warehouse" "test" {
- name = "%s"
+ name = tabular_warehouse.test.name
 }
-`, bucketName, roleArn, name, name)
+`, bucketName, roleArn, name)
 }
 
 func TestAccWarehouseDataSourceById(t *testing.T) {


### PR DESCRIPTION
Noticed while fixing local tests in the [retry PR](https://github.com/tabular-io/terraform-provider-tabular/pull/36) that the test was failing to find the warehouse. Since it was not a terraform reference, terraform did not know to wait until the resource was created before loading the data source of it