### PR TITLE
Return both parts warehouse_id/database_id

### DIFF
--- a/internal/provider/database.go
+++ b/internal/provider/database.go
@@ -95,9 +95,10 @@ func (r *databaseResource) Schema(ctx context.Context, req resource.SchemaReques
 }
 
 func (r *databaseResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	parts := strings.SplitN(req.ID, "/", 1)
+	parts := strings.SplitN(req.ID, "/", 2)
 	if len(parts) != 2 {
 		resp.Diagnostics.AddError("Could not parse ", "Expected warehouseId/databaseId")
+		return
 	}
 	state := databaseResourceModel{
 		WarehouseId: types.StringValue(parts[0]),


### PR DESCRIPTION
- Fix off by one that would only capture warehouse id
- return if the id does not match <warehouse_id/database_id>

Fixes: https://github.com/tabular-io/terraform-provider-tabular/issues/38