### PR TITLE
General fixes for tabular_database resource

### DIFF
--- a/examples/resources/tabular_database/import.sh
+++ b/examples/resources/tabular_database/import.sh
@@ -1,2 +1,2 @@
-# Databases can be imported with the `Warehouse ID/Database Name` format
-terraform import tabular_database.some_database "2f8efb1d-81f6-4b83-8fae-ec30653a89eb/A Database Name"
+# Databases can be imported with the `Warehouse ID/Database ID` format
+terraform import tabular_database.some_database "2f8efb1d-81f6-4b83-8fae-ec30653a89eb/c77ed1e7-a235-4156-a252-8ac5b8215145"


### PR DESCRIPTION
## Changes
- Correct 404 handling to remove the resource from state, instead of panciking
- Correct import example, to reflect the v2 client using an endpoint that expects a database ID, not a name
- Adjusted retry wrapper to only retry for non-4xx status codes
- Adjusted default retry configuration to fail faster; very few cases that should be retried will succeed after 5 minutes instead of 2.